### PR TITLE
python3: Fails to copy images from urls

### DIFF
--- a/bmaptools/CLI.py
+++ b/bmaptools/CLI.py
@@ -151,7 +151,7 @@ def verify_detached_bmap_signature(args, bmap_obj, bmap_path):
     # If the stand-alone signature file is not local, make a local copy
     if sig_obj.is_url:
         try:
-            tmp_obj = tempfile.NamedTemporaryFile("w+")
+            tmp_obj = tempfile.NamedTemporaryFile("wb+")
         except IOError as err:
             log.error("cannot create a temporary file for the "
                       "signature: %s" % err)
@@ -327,7 +327,7 @@ def find_and_open_bmap(args):
 
     try:
         # Create a temporary file for the bmap
-        tmp_obj = tempfile.NamedTemporaryFile("w+")
+        tmp_obj = tempfile.NamedTemporaryFile("wb+")
     except IOError as err:
         log.error("cannot create a temporary file for bmap: %s" % err)
         raise SystemExit(1)

--- a/bmaptools/TransRead.py
+++ b/bmaptools/TransRead.py
@@ -499,6 +499,7 @@ class TransRead(object):
         else:
             import http.client as httplib
             import urllib.request as urllib2
+            self._force_fake_seek = True
 
         parsed_url = urlparse.urlparse(url)
 


### PR DESCRIPTION
Trying to create an image from an url results in the following errors:

-With bmap
```
sudo bmaptool copy  http://****.com/qtec/europa/images/qt5022/qimage-dev-qt5022.wic  /dev/sdb
bmaptool: info: discovered bmap file 'http://tftp.qtec.com/qtec/europa/images/qt5022/qimage-dev-qt5022.wic.bmap'
Traceback (most recent call last):
  File "/usr/bin/bmaptool", line 11, in <module>
    sys.exit(main())
  File "/usr/lib/python3/dist-packages/bmaptools/CLI.py", line 715, in main
    args.func(args)
  File "/usr/lib/python3/dist-packages/bmaptools/CLI.py", line 423, in copy_command
    open_files(args)
  File "/usr/lib/python3/dist-packages/bmaptools/CLI.py", line 365, in open_files
    (bmap_obj, bmap_path) = find_and_open_bmap(args)
  File "/usr/lib/python3/dist-packages/bmaptools/CLI.py", line 335, in find_and_open_bmap
    shutil.copyfileobj(bmap_obj, tmp_obj)
  File "/usr/lib/python3.6/shutil.py", line 82, in copyfileobj
    fdst.write(buf)
  File "/usr/lib/python3.6/tempfile.py", line 622, in func_wrapper
    return func(*args, **kwargs)
TypeError: write() argument must be str, not bytes

```

-Without bmap:

```
sudo bmaptool copy --nobmap  http://***.com/qtec/europa/images/qt5022/qimage-dev-qt5022.wic  /dev/sdb
bmaptool: WARNING: "/dev/sdb" is under "/dev", but it is a regular file, not a device node
bmaptool: info: no bmap given, copy entire image to '/dev/sdb'
Traceback (most recent call last):
  File "/usr/bin/bmaptool", line 11, in <module>
    sys.exit(main())
  File "/usr/lib/python3/dist-packages/bmaptools/CLI.py", line 715, in main
    args.func(args)
  File "/usr/lib/python3/dist-packages/bmaptools/CLI.py", line 477, in copy_command
    writer.copy(False, not args.no_verify)
  File "/usr/lib/python3/dist-packages/bmaptools/BmapCopy.py", line 584, in copy
    raise exc_info[1].with_traceback(exc_info[2])
  File "/usr/lib/python3/dist-packages/bmaptools/BmapCopy.py", line 503, in _get_data
    self._f_image.seek(first * self.block_size)
  File "/usr/lib/python3/dist-packages/bmaptools/TransRead.py", line 587, in seek
    self._f_objs[-1].seek(offset, whence)
io.UnsupportedOperation: seek

```

This patch fixes both issues for python3. Tested with debian-9

Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>