### PR TITLE
Fix copying bmap and signature files

### DIFF
--- a/bmaptools/CLI.py
+++ b/bmaptools/CLI.py
@@ -151,7 +151,7 @@ def verify_detached_bmap_signature(args, bmap_obj, bmap_path):
     # If the stand-alone signature file is not local, make a local copy
     if sig_obj.is_url:
         try:
-            tmp_obj = tempfile.NamedTemporaryFile("w+")
+            tmp_obj = tempfile.NamedTemporaryFile("wb+")
         except IOError as err:
             log.error("cannot create a temporary file for the "
                       "signature: %s" % err)
@@ -327,7 +327,7 @@ def find_and_open_bmap(args):
 
     try:
         # Create a temporary file for the bmap
-        tmp_obj = tempfile.NamedTemporaryFile("w+")
+        tmp_obj = tempfile.NamedTemporaryFile("wb+")
     except IOError as err:
         log.error("cannot create a temporary file for bmap: %s" % err)
         raise SystemExit(1)


### PR DESCRIPTION
When copying from a remote host, we first create a temporary copy
of the bmap and signature files locally. Unfortunately that does
not work in python3 and fails with this symptom:

$ python3 ./bmaptool -d copy https://xyz/image.raw ~/tmp/file
Traceback (most recent call last):
  File "./bmaptool", line 11, in <module>
    sys.exit(main())
  File "/home/abityuts/git/bmap-tools/bmaptools/CLI.py", line 715, in main
    args.func(args)
  File "/home/abityuts/git/bmap-tools/bmaptools/CLI.py", line 477, in copy_command
    writer.copy(False, not args.no_verify)
  File "/home/abityuts/git/bmap-tools/bmaptools/BmapCopy.py", line 584, in copy
    raise exc_info[1].with_traceback(exc_info[2])
  File "/home/abityuts/git/bmap-tools/bmaptools/BmapCopy.py", line 503, in _get_data
    self._f_image.seek(first * self.block_size)
  File "/home/abityuts/git/bmap-tools/bmaptools/TransRead.py", line 587, in seek
    self._f_objs[-1].seek(offset, whence)
io.UnsupportedOperation: seek

This patch originally came from Ricardo Ribalda Delgado (ribalda in github).
I've simply re-formatted it.

Change-Id: I940c745accb99cef990628bd71257dc845b709f2
Signed-off-by: Artem Bityutskiy <artem.bityutskiy@intel.com>