### PR TITLE
TransRead: unbreak reading compressed file from an URL

### DIFF
--- a/bmaptools/TransRead.py
+++ b/bmaptools/TransRead.py
@@ -380,10 +380,10 @@ class TransRead(object):
         else:
             args = decompressor + " " + args
 
-        if hasattr(self._f_objs[-1], 'fileno'):
-            child_stdin = self._f_objs[-1].fileno()
-        else:
+        if self.is_url:
             child_stdin = subprocess.PIPE
+        else:
+            child_stdin = self._f_objs[-1].fileno()
 
         child_process = subprocess.Popen(args, shell=True,
                                          bufsize=1024 * 1024,
@@ -392,6 +392,8 @@ class TransRead(object):
                                          stderr=subprocess.PIPE)
 
         if child_stdin == subprocess.PIPE:
+            # A separate reader thread is created only when we are reading via
+            # liburl.
             args = (self._f_objs[-1], child_process.stdin, )
             self._rthread = threading.Thread(target=self._read_thread, args=args)
             self._rthread.daemon = True

--- a/bmaptools/TransRead.py
+++ b/bmaptools/TransRead.py
@@ -167,7 +167,7 @@ class TransRead(object):
         #
         # For example, when the path is an URL to a bz2 file, the chain of
         # opened file will be:
-        #   o self._f_objs[0] is the liburl2 file-like object
+        #   o self._f_objs[0] is the urllib2 file-like object
         #   o self._f_objs[1] is the stdout of the 'bzip2' process
         self._f_objs = []
 
@@ -393,7 +393,7 @@ class TransRead(object):
 
         if child_stdin == subprocess.PIPE:
             # A separate reader thread is created only when we are reading via
-            # liburl.
+            # urllib2.
             args = (self._f_objs[-1], child_process.stdin, )
             self._rthread = threading.Thread(target=self._read_thread, args=args)
             self._rthread.daemon = True
@@ -505,7 +505,7 @@ class TransRead(object):
         parsed_url = urlparse.urlparse(url)
 
         if parsed_url.scheme == "ssh":
-            # Unfortunately, liburl2 does not handle "ssh://" URLs
+            # Unfortunately, urllib2 does not handle "ssh://" URLs
             self._open_url_ssh(parsed_url)
             return
 


### PR DESCRIPTION
This patch fixes a regression introduced by commit 6343239fb2487c309c9573ee35e7832b08753180 -
reading a compressed file from an URL stopped working. Apparently urllib's file-like objects do have
a 'fileno', but reading from it gives EOF immediately. So lets use 'is_url' to make a decision about
whether we create a reader thread or not.

Change-Id: I6ba9570f823f3943f202d4b0170782a74aa0333e
Signed-off-by: Artem Bityutskiy <artem.bityutskiy@intel.com>