### PR TITLE
bmaptools/CLI.py: Print help in case of no arguments

### DIFF
--- a/bmaptools/CLI.py
+++ b/bmaptools/CLI.py
@@ -584,7 +584,8 @@ def parse_arguments():
     text = "print debugging information"
     parser.add_argument("-d", "--debug", action="store_true", help=text)
 
-    subparsers = parser.add_subparsers(title="commands")
+    subparsers = parser.add_subparsers(title="commands", dest="command")
+    subparsers.required = True
 
     #
     # Create parser for the "create" command


### PR DESCRIPTION
This fix avoids the following run-time exception:

    $ bmaptool
    Traceback (most recent call last):
      File "/usr/bin/bmaptool", line 11, in <module>
        load_entry_point('bmap-tools==3.4', 'console_scripts', 'bmaptool')()
      File "/usr/lib/python3.6/site-packages/bmaptools/CLI.py", line 715, in main
        args.func(args)
    AttributeError: 'Namespace' object has no attribute 'func'

Suggested by: Simon McVittie [https://github.com/intel/bmap-tools/pull/51#issuecomment-398161212]