### PR TITLE
BmapCopy: Do not show a warning if noop io scheduder is not available

### DIFF
--- a/bmaptools/BmapCopy.py
+++ b/bmaptools/BmapCopy.py
@@ -722,9 +722,9 @@ class BmapBdevCopy(BmapCopy):
                 f_scheduler.seek(0)
                 f_scheduler.write("noop")
         except IOError as err:
-            _log.warning("failed to enable I/O optimization, expect "
+            _log.debug("failed to enable I/O optimization, expect "
                          "suboptimal speed (reason: cannot switch to the "
-                         "'noop' I/O scheduler: %s)" % err)
+                         "'noop' I/O scheduler: %s or blk-mq in use)" % err)
         else:
             # The file contains a list of schedulers with the current
             # scheduler in square brackets, e.g., "noop deadline [cfq]".


### PR DESCRIPTION
New Linux Multi-Queue Block IO Queueing Mechanism does not have a noop
scheduler, which result in an error when trying to set the io scheduler.

Also according to the linux-blk maintainers:

"""
don't change the default io scheduler as none, which shouldn't
work well for slow disk, such as non-SSD.
"""

So, this patch basically does not bother the user if noop is not
available following this rationale :

If noop is not available is because the kernel is using multi queue
and then we should not change the io scheduler.

Fixes: #55
Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>