### PR TITLE
Filemap: catch StopIteration from next(iterator)

### DIFF
--- a/bmaptools/Filemap.py
+++ b/bmaptools/Filemap.py
@@ -476,7 +476,11 @@ class FilemapFiemap(_FilemapBase):
         _log.debug("FilemapFiemap: get_mapped_ranges(%d,  %d(%d))"
                    % (start, count, start + count - 1))
         iterator = self._do_get_mapped_ranges(start, count)
-        first_prev, last_prev = next(iterator)
+
+        try:
+            first_prev, last_prev = next(iterator)
+        except StopIteration:
+            return
 
         for first, last in iterator:
             if last_prev == first - 1:


### PR DESCRIPTION
In Python >= 3.7, if code in a generator raises StopIteration, it is
transformed into a RuntimeError instead of terminating the generator
gracefully.

Closes: https://github.com/intel/bmap-tools/issues/57  
Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=915686