### PR TITLE
test_api_base: Skip test if filesystem is unsuitable

### DIFF
--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -135,6 +135,12 @@ def _do_test(image, image_size, delete=True):
     have to be automatically deleted.
     """
 
+    try:
+        Filemap.filemap(image)
+    except Filemap.ErrorNotSupp as e:
+        sys.stderr.write('%s\n' % e)
+        return
+
     # Make sure the temporary files start with the same name as 'image' in
     # order to simplify debugging.
     prefix = os.path.splitext(os.path.basename(image))[0] + '.'


### PR DESCRIPTION
When run on disorderfs (an artificial FUSE filesystem used by the
Reproducible Builds project to detect filesystem order dependencies),
we cannot map the file to detect holes. The same is likely to be true
for other simple FUSE filesystems.