### PR TITLE
Always close the decompressor stdin

### DIFF
--- a/bmaptools/TransRead.py
+++ b/bmaptools/TransRead.py
@@ -206,16 +206,17 @@ class TransRead(object):
         """
 
         chunk_size = 1024 * 1024
-        while not self._done:
-            buf = f_from.read(chunk_size)
-            if not buf:
-                break
+        try:
+            while not self._done:
+                buf = f_from.read(chunk_size)
+                if not buf:
+                    break
 
-            f_to.write(buf)
-
-        # This will make sure the process decompressor gets EOF and exits, as
-        # well as ublocks processes waiting on decompressor's stdin.
-        f_to.close()
+                f_to.write(buf)
+        finally:
+            # This will make sure the process decompressor gets EOF and exits, as
+            # well as ublocks processes waiting on decompressor's stdin.
+            f_to.close()
 
     def _open_compressed_file(self):
         """


### PR DESCRIPTION
If the TransRead read thread for some reason hits an exception (e.g. the
http connection got reset) the standard input from the decompressor
should still be closed otherwise bmaptool will just block without ever
detecting the read thread exploded.

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>