### PR TITLE
bmaptool: CLI: Fail when copying a bmap file

### DIFF
--- a/bmaptools/CLI.py
+++ b/bmaptools/CLI.py
@@ -385,10 +385,10 @@ def open_files(args):
 
     if bmap_path == args.image:
         # Most probably the user specified the bmap file instead of the image
-        # file by mistake. Don't let bmaptool copy any data
+        # file by mistake.
         bmap_obj.close()
-        error_out("Make sure you are flashing your image and not the bmap file "
-                  "because they have the same path.")
+        error_out("Make sure you are writing your image and not the bmap file "
+                  "(you specified the same path for them)")
 
     # If the destination file is under "/dev", but does not exist, print a
     # warning. This is done in order to be more user-friendly, because

--- a/bmaptools/CLI.py
+++ b/bmaptools/CLI.py
@@ -384,13 +384,11 @@ def open_files(args):
     (bmap_obj, bmap_path) = find_and_open_bmap(args)
 
     if bmap_path == args.image:
-        # Most probably the specified the bmap file instead of the image file
-        # by mistake.
-        log.warning("image has the same path as the bmap file, dropping bmap")
+        # Most probably the user specified the bmap file instead of the image
+        # file by mistake. Don't let bmaptool copy any data
         bmap_obj.close()
-        bmap_obj = None
-        bmap_path = None
-        args.nobmap = True
+        error_out("Make sure you are flashing your image and not the bmap file "
+                  "because they have the same path.")
 
     # If the destination file is under "/dev", but does not exist, print a
     # warning. This is done in order to be more user-friendly, because


### PR DESCRIPTION
Hello everyone, 

While using bmaptools with [debos](https://godoc.org/github.com/go-debos/debos), got an issue while copying the bmap file instead of the image file (by mistake). The error message was :

```
bmaptool: info: discovered bmap file 'in.bmap'
bmaptool: WARNING: image has the same path as the bmap file, dropping bmap
bmaptool: info: no bmap given, copy entire image to 'out'
bmaptool: info: 100% copied
bmaptool: info: synchronizing 'out'
bmaptool: info: copying time: 0.0s, copying speed 147.0 KiB/sec
```
It indicates that the entier image is copied. First, I did not realize my mistake and I thought that my image was correctly copied to my SD-card. In fact, it is copying the bmap file into the block device which is not what we want.

This commit will update it as an error instead of a warning and try to be more explicit.

Let me know what you think of it and if there is a better approach for this bug.

Best regards,
Mylène
