### PR TITLE
Update python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev" # 3.7 development branch
-  - "nightly" # currently points to 3.6-dev
+  - "3.7"
+  - "3.9"
 # pypy 2.x currently disabled, until testing fixed.
 #  - "pypy"
 #  - "pypy3"


### PR DESCRIPTION
Remove v2.6, I do not think we want to support it. Add newest python 3.x versions.

Signed-off-by: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>