### PR TITLE
Use Python standard library in preference to external modules

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 six
 nose
-backports.tempfile
+backports.tempfile ; python_version < '3.2'
 mock ; python_version < '3.3'

--- a/tests/test_bmap_helpers.py
+++ b/tests/test_bmap_helpers.py
@@ -25,7 +25,10 @@ try:
     from unittest.mock import patch, mock
 except ImportError:     # for Python < 3.3
     from mock import patch, mock
-from backports import tempfile as btempfile
+try:
+    from tempfile import TemporaryDirectory
+except ImportError:     # for Python < 3.2
+    from backports.tempfile import TemporaryDirectory
 from bmaptools import BmapHelpers
 
 
@@ -58,7 +61,7 @@ class TestBmapHelpers(unittest.TestCase):
     def test_get_file_system_type_symlink(self):
         """Check a file system type is returned when used with a symlink"""
 
-        with btempfile.TemporaryDirectory(prefix="testdir_", dir=".") as directory:
+        with TemporaryDirectory(prefix="testdir_", dir=".") as directory:
             fobj = tempfile.NamedTemporaryFile("r", prefix="testfile_", delete=False,
                                             dir=directory, suffix=".img")
             lnk = os.path.join(directory, "test_symlink")


### PR DESCRIPTION
* tests: Use unittest.mock from Python standard library if possible
    
    This avoids an unnecessary external dependency when using Python >= 3.3.

* tests: Try to use TemporaryDirectory from Python standard library
    
    This avoids an unnecessary external dependency with Python >= 3.2.