### PR TITLE
tests: Pass -c -k options to zstd, too

### DIFF
--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -91,7 +91,7 @@ def _generate_compressed_files(file_path, delete=True):
                    ("xz",     None, ".xz",    "-c -k"),
                    ("lzop",   None, ".lzo",   "-c -k"),
                    ("lz4",    None, ".lz4",   "-c -k"),
-                   ("zstd",   None, ".zst",   ""),
+                   ("zstd",   None, ".zst",   "-c -k"),
                    # The "-P -C /" trick is used to avoid silly warnings:
                    # "tar: Removing leading `/' from member names"
                    ("bzip2", "tar", ".tar.bz2", "-c -j -O -P -C /"),


### PR DESCRIPTION
Otherwise we get interactive prompts during testing, like this:

    zstd: /*stdin*\: unexpected end of file
    zstd: /*stdin*\: unexpected end of file
    zstd: /*stdin*\: unexpected end of file
    zstd: /*stdin*\: unexpected end of file
    zstd: .../.pybuild/cpython3_3.9/build/4Khole_idts5mgb.img.zst already exists; overwrite (y/n) ?
