### PR TITLE
Drop python 3.2 and python 3.3 backports

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -103,7 +103,7 @@ a 4GiB file with all blocks unmapped, which means that the file consists of a
 huge 4GiB hole:
 
 ```bash
-$ truncate -s4G image.raw
+$ truncate -s 4G image.raw
 $ stat image.raw
   File: image.raw
   Size: 4294967296   Blocks: 0     IO Block: 4096   regular file

--- a/tests/test_bmap_helpers.py
+++ b/tests/test_bmap_helpers.py
@@ -21,14 +21,8 @@ This test verifies 'BmapHelpers' module functionality.
 import os
 import sys
 import tempfile
-try:
-    from unittest.mock import patch
-except ImportError:     # for Python < 3.3
-    from mock import patch
-try:
-    from tempfile import TemporaryDirectory
-except ImportError:     # for Python < 3.2
-    from backports.tempfile import TemporaryDirectory
+from unittest.mock import patch
+from tempfile import TemporaryDirectory
 from bmaptools import BmapHelpers
 
 


### PR DESCRIPTION
As they are EOL since 2017 (for 3.3) don't you think it's time to drop these and reduce the required amounts of packages. Time to move to 3.9/3.10 and make some cleanups