### PR TITLE
Fix path parameter passing error of set_psplash_pipe function

### DIFF
--- a/bmaptools/BmapCopy.py
+++ b/bmaptools/BmapCopy.py
@@ -228,11 +228,11 @@ class BmapCopy(object):
         a best effort.
         """
 
-        if os.path.exists(pipe) and stat.S_ISFIFO(os.stat(pipe).st_mode):
-            self._psplash_pipe = pipe
+        if os.path.exists(path) and stat.S_ISFIFO(os.stat(path).st_mode):
+            self._psplash_pipe = path
         else:
             _log.warning("'%s' is not a pipe, so psplash progress will not be "
-                         "updated" % pipe)
+                         "updated" % path)
 
     def set_progress_indicator(self, file_obj, format_string):
         """


### PR DESCRIPTION
It would cause the following error while using —psplash-pipe:
```
sudo bmaptool copy xxx.xz /dev/sdb --psplash-pipe progress

Traceback (most recent call last):
  File "/usr/local/bin/bmaptool", line 11, in <module>
    load_entry_point('bmap-tools==3.6', 'console_scripts', 'bmaptool')()
  File "/usr/local/lib/python3.8/dist-packages/bmap_tools-3.6-py3.8.egg/bmaptools/CLI.py", line 725, in main
  File "/usr/local/lib/python3.8/dist-packages/bmap_tools-3.6-py3.8.egg/bmaptools/CLI.py", line 486, in copy_command
  File "/usr/local/lib/python3.8/dist-packages/bmap_tools-3.6-py3.8.egg/bmaptools/BmapCopy.py", line 231, in set_psplash_pipe
NameError: name 'pipe' is not defined
```