### PR TITLE
Add basic copying from stdin

### DIFF
--- a/bmaptools/TransRead.py
+++ b/bmaptools/TransRead.py
@@ -174,7 +174,10 @@ class TransRead(object):
         self._pos = 0
 
         try:
-            self._f_objs.append(open(self.name, "rb"))
+            if self.name == "-":
+                self._f_objs.append(sys.stdin.buffer)
+            else:
+                self._f_objs.append(open(self.name, "rb"))
         except IOError as err:
             if err.errno == errno.ENOENT:
                 # This is probably an URL

--- a/docs/man1/bmaptool.1
+++ b/docs/man1/bmaptool.1
@@ -122,7 +122,8 @@ extensions are supported:
 IMAGE files with other extensions are assumed to be uncompressed. Note,
 \fIbmaptool\fR uses "\fIpbzip2\fR" and "\fIpigz\fR" programs for decompressing
 bzip2 and gzip archives faster, unless they are not available, in which case if
-falls-back to using "\fIbzip2\fR" and "\fIgzip\fR".
+falls-back to using "\fIbzip2\fR" and "\fIgzip\fR". Furthermore, uncompressed
+IMAGE files can be piped to the standard input using "-".
 
 .PP
 If DEST is a block device node (e.g., "/dev/sdg"), \fIbmaptool\fR opens it in
@@ -248,6 +249,14 @@ too.
 Copy non-compressed local file "image.raw" to block device "/dev/sdg" using bmap file
 "image.bmap". Verify the bmap file signature using a detached OpenPGP signature
 from "imag.bmap.asc".
+.RE
+.RE
+
+.RS 2
+cat image.raw | \fIbmaptool\fR copy --bmap image.bmap - /dev/sdg
+.RS 2
+Copy non-compressed image from standard input to block device "/dev/sdg" using bmap file
+"image.bmap".
 .RE
 .RE
 


### PR DESCRIPTION
This adds basic functionality for copying files from the standard input, as proposed in #74. For example:

```sh
cat image.raw | bzip2 -d -c | sudo python bmaptool copy - /dev/sda --nobmap
```

It would be nice if `bmaptool` could handle the decompression of piped images as well, but this is not possible with the current file/compression type checks based on the file ending. I see two possible options two handle this:

1. Adding a `--file-type` or `--compression-type` flag to manually specify the type of archive/compression.
2. Integrate file type checks with file signatures using [python-magic](https://pypi.org/project/python-magic/), which strikes me as a better option. This would simplify the existing code for identifying the type of archive/compression and would also prevent decompression errors due to incorrectly set file extensions of image files. I'd be happy to implement this and open a separate PR.

