### PR TITLE
Fix some unnecessary warnings, update i/o scheduler

### DIFF
--- a/bmaptools/TransRead.py
+++ b/bmaptools/TransRead.py
@@ -502,6 +502,8 @@ class TransRead(object):
                 "-p" + password,
                 "ssh",
                 "-o StrictHostKeyChecking=no",
+                "-o ClearAllForwardings=yes",
+                "-o ForwardX11=no",
                 "-o PubkeyAuthentication=no",
                 "-o PasswordAuthentication=yes",
                 hostname,
@@ -517,6 +519,8 @@ class TransRead(object):
             popen_args = [
                 "ssh",
                 "-o StrictHostKeyChecking=no",
+                "-o ClearAllForwardings=yes",
+                "-o ForwardX11=no",
                 "-o PubkeyAuthentication=yes",
                 "-o PasswordAuthentication=no",
                 "-o BatchMode=yes",


### PR DESCRIPTION
These commits fix some warnings I came across when running bmaptool as a non-root user.
ssh is now told not to open any port forwardings even if configured in ssh_config.
The sysfs optimizations are updated to use the 'none' scheduler instead of noop (fixes #97 ), don't cause access warnings when the correct values are already set, and emit a suggestion for a udev rule otherwise.