### PR TITLE
pyproject.toml: Move nose from dependencies to dev-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,11 @@ authors = ["Artem Bityutskiy <dedekind1@gmail.com>"]
 [tool.poetry.dependencies]
 python = "^3.8"
 six = "^1.16.0"
-nose = "^1.3.7"
 gpg = "^1.10.0"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"
+nose = "^1.3.7"
 
 [tool.poetry.scripts]
 bmaptool = "bmaptools.CLI:main"


### PR DESCRIPTION
This is only needed when running the build-time tests, and is not needed for ordinary use of the tool.