### PR TITLE
Release 3.7 needs new tag

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,10 @@
 bmap-tools (3.7) unstable; urgency=low
 
+
+ -- Artem Bityutskiy <artem.bityutskiy@linux.intel.com> Wed, 02 Aug 2023 15:08:21 +0300
+
+bmap-tools (3.7) unstable; urgency=low
+
   * Use GitHub Actions for CI (#109)
   * Add `poetry` for dependency management and `black` for code formatting
     (#104)

--- a/packaging/bmap-tools.changes
+++ b/packaging/bmap-tools.changes
@@ -1,4 +1,4 @@
-Wed Aug  2 12:11:26 PM UTC 2023 - Artem Bityutskiy <artem.bityutskiy@linux.intel.com> 3.7-1
+Wed Aug  2 11:51:45 AM UTC 2023 - Artem Bityutskiy <artem.bityutskiy@linux.intel.com> 3.7-1
 - Use GitHub Actions for CI (#109)
 - Add `poetry` for dependency management and `black` for code formatting (#104)
 - Add functionality for copying from standard input (#99)


### PR DESCRIPTION
After rebasing, seems like only the first change below is really worth keeping, since the tag really needs to be deleted and then (re)created on *main* branch after merging.  This project is definitely simple enough to use the basic GitHub workflow, ie, feature and fix branches get merged to main and releases get tagged *only on the main branch*.  Today I should be able to add some github workflows to automate pretty much everything from a tag push.