### PR TITLE
bmaptools: Use df -P for POSIX portable output

### DIFF
--- a/bmaptools/BmapHelpers.py
+++ b/bmaptools/BmapHelpers.py
@@ -104,7 +104,7 @@ def get_file_system_type(path):
     """Return the file system type for 'path'."""
 
     abspath = os.path.realpath(path)
-    proc = subprocess.Popen(["df", "-T", "--", abspath], stdout=PIPE, stderr=PIPE)
+    proc = subprocess.Popen(["df", "-PT", "--", abspath], stdout=PIPE, stderr=PIPE)
     stdout, stderr = proc.communicate()
 
     # Parse the output of subprocess, for example:
@@ -121,7 +121,7 @@ def get_file_system_type(path):
     if not ftype:
         raise Error(
             "failed to find file system type for path at '%s'\n"
-            "Here is the 'df -T' output\nstdout:\n%s\nstderr:\n%s"
+            "Here is the 'df -PT' output\nstdout:\n%s\nstderr:\n%s"
             % (path, stdout, stderr)
         )
     return ftype


### PR DESCRIPTION
The df -P option forces output as specified by POSIX.  Without -P df can output any format it likes.  While most output is the same, I've seen long lines split onto multiple lines without -P which causes errors parsing the output in BmapHelpers.py.

Add -P to ensure a known portable output and avoid errors with long lines.